### PR TITLE
Feature/function keys

### DIFF
--- a/src/samplerfacade.jl
+++ b/src/samplerfacade.jl
@@ -15,6 +15,9 @@ struct SamplerFacade{S,key}
 end
 
 
+current_time(s::SamplerFacade) = s.sampler.when
+
+
 function enable!(
     facade::SamplerFacade,
     clock,

--- a/src/system.jl
+++ b/src/system.jl
@@ -2,9 +2,12 @@ import CompetingClocks: FirstToFire, SingleSampler
 
 export run_experiment
 
-struct NullObserver end
+mutable struct NullObserver
+    called::Int64
+    NullObserver() = new(0)
+end
 
-observe(experiment, observer::NullObserver, when, which) = nothing
+observe(experiment, observer::NullObserver, when, which) = (observer.called += 1; nothing)
 
 
 function run_experiment(experiment, observation, days)
@@ -13,14 +16,15 @@ function run_experiment(experiment, observation, days)
     facade = SamplerFacade{typeof(sampler),key_type(experiment)}(sampler)
     rng = experiment.rng
     when = zero(Float64)
-    initial_events(experiment, facade, when)
+    initial_events(experiment, facade)
 
     when, which = sample!(facade, rng)
     while isfinite(when) && when < days
         ## We use different observers to record the simulation.
         observe(experiment, observation, when, which)
         @debug "$when $which"
-        fire!(when, which, experiment, facade)
+        action, who = which
+        action(experiment, facade, who)
         when, which = sample!(facade, rng)
     end
 end

--- a/src/trucks.jl
+++ b/src/trucks.jl
@@ -27,7 +27,6 @@ end
 
 
 function start_truck(experiment, truck::Truck, sampler)
-    now = experiment.time
     rng = experiment.rng
     truck.state = working
     # Start the :done and :break transitions at the same time.
@@ -85,7 +84,7 @@ end
 
 
 function start_tomorrow(management, experiment, sampler)
-    now = experiment.time
+    now = current_time(sampler)
     # Set up the event for tomorrow
     eightam = Dirac(next_work_time(now, management.work_day_fraction) - now)
     enable!(sampler, (0, :work), eightam, experiment.rng)
@@ -93,7 +92,6 @@ end
 
 
 function start_the_day(management, experiment, sampler)
-    now = experiment.time
     for truck_idx in shuffle(experiment.rng, Vector(1:management.total))
         individual = truck(experiment, truck_idx)
         if individual.state == ready
@@ -124,12 +122,10 @@ end
 
 
 mutable struct TruckExperiment
-    time::Float64
     group::Vector{Truck}
     management::TruckingManagement
     rng::Xoshiro
     TruckExperiment(group::Vector, crew_size::Int, rng) = new(
-        0.0,
         group,
         TruckingManagement(crew_size, length(group)),
         rng
@@ -159,7 +155,6 @@ end
 
 
 function fire!(when::Float64, transition_id, experiment::TruckExperiment, sampler)
-    experiment.time = when
     who, transition_kind = transition_id
     if who == 0
         start_the_day(experiment.management, experiment, sampler)

--- a/test/test_trucks.jl
+++ b/test/test_trucks.jl
@@ -13,4 +13,5 @@ using SafeTestsets
     day_cnt = 10
     observer = TruckReliability.NullObserver()
     run_experiment(experiment, observer, day_cnt)
+    @assert observer.called > 100
 end


### PR DESCRIPTION
The firing method for this simulation looks a lot like it just calls the relevant function for each truck. What if we made the "key" for the transition a tuple of (function to call for firing, an integer to pass to that function)? That's what this does. It always calls callback(experiment, sampler, the integer).